### PR TITLE
Search indexing and translations

### DIFF
--- a/src/Search/SearchEngine.php
+++ b/src/Search/SearchEngine.php
@@ -205,10 +205,18 @@ class SearchEngine extends Engine
          * then translate it and use
          * that array data to index.
          *
+         * Keep any fields that don't have a translation
+         * as the default locale
+         *
          * @var EntryTranslationsModel|EntryModel $translation
          */
         if ($model->isTranslatable() && $translation = $model->translateOrDefault($locale)) {
-            $array = array_merge($translation->toArray(), $array);
+            $array = array_merge(
+                $array,
+                array_filter($translation->toArray(), function ($item) {
+                    return !empty($item);
+                })
+            );
         }
 
         if (!$item = $this->items->findByEntryAndLocale($model, $locale)) {

--- a/src/Search/SearchEngine.php
+++ b/src/Search/SearchEngine.php
@@ -213,9 +213,13 @@ class SearchEngine extends Engine
         if ($model->isTranslatable() && $translation = $model->translateOrDefault($locale)) {
             $array = array_merge(
                 $array,
-                array_filter($translation->toArray(), function ($item) {
-                    return !empty($item);
-                })
+                array_filter(
+                    $translation->toArray(),
+                    function ($item, $key) use ($array) {
+                        return !empty($item) && in_array($key, array_keys($array));
+                    },
+                    ARRAY_FILTER_USE_BOTH
+                )
             );
         }
 


### PR DESCRIPTION
A few fixes for translations in search indexes:
- Give the translated content priority over the default content when indexing for a locale. 
- Ignore any empty values in the translations and fall back to the default translations to match what happens when fetching content for render.
- Only use translated values that match a key in the original `$array` so that the `searchable` field doesn't get polluted with meta data and additional fields.